### PR TITLE
fix!: update to use @terraformer packages

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "cSpell.words": [
+        "terraformer"
+    ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -12375,9 +12375,9 @@
             }
         },
         "node_modules/terser": {
-            "version": "5.14.1",
-            "resolved": "https://registry.npmjs.org/terser/-/terser-5.14.1.tgz",
-            "integrity": "sha512-+ahUAE+iheqBTDxXhTisdA8hgvbEG1hHOQ9xmNjeUJSoi6DU/gMrKNcfZjHkyY6Alnuyc+ikYJaxxfHkT3+WuQ==",
+            "version": "5.15.0",
+            "resolved": "https://registry.npmjs.org/terser/-/terser-5.15.0.tgz",
+            "integrity": "sha512-L1BJiXVmheAQQy+as0oF3Pwtlo4s3Wi1X2zNZ2NxOB4wx9bdS9Vk67XQENLFdLYGCK/Z2di53mTj/hBafR+dTA==",
             "dev": true,
             "dependencies": {
                 "@jridgewell/source-map": "^0.3.2",
@@ -22877,9 +22877,9 @@
             }
         },
         "terser": {
-            "version": "5.14.1",
-            "resolved": "https://registry.npmjs.org/terser/-/terser-5.14.1.tgz",
-            "integrity": "sha512-+ahUAE+iheqBTDxXhTisdA8hgvbEG1hHOQ9xmNjeUJSoi6DU/gMrKNcfZjHkyY6Alnuyc+ikYJaxxfHkT3+WuQ==",
+            "version": "5.15.0",
+            "resolved": "https://registry.npmjs.org/terser/-/terser-5.15.0.tgz",
+            "integrity": "sha512-L1BJiXVmheAQQy+as0oF3Pwtlo4s3Wi1X2zNZ2NxOB4wx9bdS9Vk67XQENLFdLYGCK/Z2di53mTj/hBafR+dTA==",
             "dev": true,
             "requires": {
                 "@jridgewell/source-map": "^0.3.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
             "version": "0.0.0-semantically-released",
             "license": "MIT",
             "dependencies": {
-                "terraformer-arcgis-parser": "^1.1.0",
-                "terraformer-wkt-parser": "^1.2.1"
+                "@terraformer/arcgis": "^2.1.2",
+                "@terraformer/wkt": "^2.1.2"
             },
             "devDependencies": {
                 "@babel/core": "^7.18.5",
@@ -2597,6 +2597,24 @@
                 "@sinonjs/commons": "^1.7.0"
             }
         },
+        "node_modules/@terraformer/arcgis": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/@terraformer/arcgis/-/arcgis-2.1.2.tgz",
+            "integrity": "sha512-IvdfqehcNAUtKU1OFMKwPT8EvdKlVFZ7q7ZKzkIF8XzYZIVsZLuXuOS1UBdRh5u/o+X5Gax7jiZhD8U/4TV+Jw==",
+            "dependencies": {
+                "@terraformer/common": "^2.1.2"
+            }
+        },
+        "node_modules/@terraformer/common": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/@terraformer/common/-/common-2.1.2.tgz",
+            "integrity": "sha512-cwPdTFzIpekZhZRrgDEkqLKNPoqbyCBQHiemaovnGIeUx0Pl336MY/eCxzJ5zXkrQLVo9zPalq/vYW5HnyKevQ=="
+        },
+        "node_modules/@terraformer/wkt": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/@terraformer/wkt/-/wkt-2.1.2.tgz",
+            "integrity": "sha512-2AyTBWqSfvGs4mTkuOMTdnL0Em6+awGyQd6f0nAMenoRLPWG05nWxxOHP8qKJVLmfZjkr0JfIWlakPgIyNgV7g=="
+        },
         "node_modules/@ts-morph/common": {
             "version": "0.7.5",
             "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.7.5.tgz",
@@ -2757,11 +2775,6 @@
                 "@types/qs": "*",
                 "@types/range-parser": "*"
             }
-        },
-        "node_modules/@types/geojson": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-1.0.6.tgz",
-            "integrity": "sha512-Xqg/lIZMrUd0VRmSRbCAewtwGZiAk3mEUDvV4op1tGl+LvyPcb/MIOSxTl9z+9+J+R4/vpjiCAT4xeKzH9ji1w=="
         },
         "node_modules/@types/glob": {
             "version": "7.1.3",
@@ -4498,9 +4511,9 @@
             "dev": true
         },
         "node_modules/connect-history-api-fallback": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz",
-            "integrity": "sha512-e54B99q/OUoH64zYYRf3HBP5z24G38h5D3qXu23JGRoigpX5Ss4r9ZnDk3g0Z8uQC2x2lPaJ+UlWBc1ZWBWdLg==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-2.0.0.tgz",
+            "integrity": "sha512-U73+6lQFmfiNPrYbXqr6kZ1i1wiRqXnp2nhMsINseWXO8lDau0LGEffJ8kQi4EjLZympVgRdvqjAgiZ1tgzDDA==",
             "dev": true,
             "engines": {
                 "node": ">=0.8"
@@ -12361,45 +12374,10 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/terraformer": {
-            "version": "1.0.12",
-            "resolved": "https://registry.npmjs.org/terraformer/-/terraformer-1.0.12.tgz",
-            "integrity": "sha512-MokUp0+MFal4CmJDVL6VAO1bKegeXcBM2RnPVfqcFIp2IIv8EbPAjG0j/vEy/vuKB8NVMMSF2vfpVS/QLe4DBg==",
-            "deprecated": "terraformer is deprecated and no longer supported. Please use @terraformer/arcgis.",
-            "engines": {
-                "node": ">=4.2.6"
-            },
-            "optionalDependencies": {
-                "@types/geojson": "^7946.0.0 || ^1.0.0"
-            }
-        },
-        "node_modules/terraformer-arcgis-parser": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/terraformer-arcgis-parser/-/terraformer-arcgis-parser-1.1.0.tgz",
-            "integrity": "sha512-bvxEtpiS22Lz1ciaXP/MMLTlJkrHWLBV/y7VBeTLHtZnz/Ngq4wF3RqrpjzP6ojJjxvcdDlvs+UFs3wicoT1Vg==",
-            "deprecated": "terraformer-arcgis-parser is deprecated and no longer supported. Please use @terraformer/arcgis.",
-            "dependencies": {
-                "@types/geojson": "^1.0.0",
-                "terraformer": "~1.0.4"
-            }
-        },
-        "node_modules/terraformer-wkt-parser": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/terraformer-wkt-parser/-/terraformer-wkt-parser-1.2.1.tgz",
-            "integrity": "sha512-+CJyNLWb3lJ9RsZMTM66BY0MT3yIo4l4l22Jd9CrZuwzk54fsu4Sc7zejuS9fCITTuTQy3p06d4MZMVI7v5wSg==",
-            "deprecated": "terraformer-wkt-parser is deprecated and no longer supported. Please use @terraformer/wkt.",
-            "dependencies": {
-                "@types/geojson": "^1.0.0",
-                "terraformer": "~1.0.5"
-            },
-            "engines": {
-                "node": ">=4.2.6"
-            }
-        },
         "node_modules/terser": {
-            "version": "5.14.2",
-            "resolved": "https://registry.npmjs.org/terser/-/terser-5.14.2.tgz",
-            "integrity": "sha512-oL0rGeM/WFQCUd0y2QrWxYnq7tfSuKBiqTjRPWrRgB46WD/kiwHwF8T23z78H6Q6kGCuuHcPB+KULHRdxvVGQA==",
+            "version": "5.14.1",
+            "resolved": "https://registry.npmjs.org/terser/-/terser-5.14.1.tgz",
+            "integrity": "sha512-+ahUAE+iheqBTDxXhTisdA8hgvbEG1hHOQ9xmNjeUJSoi6DU/gMrKNcfZjHkyY6Alnuyc+ikYJaxxfHkT3+WuQ==",
             "dev": true,
             "dependencies": {
                 "@jridgewell/source-map": "^0.3.2",
@@ -13175,9 +13153,9 @@
             }
         },
         "node_modules/webpack-dev-server": {
-            "version": "4.9.2",
-            "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.9.2.tgz",
-            "integrity": "sha512-H95Ns95dP24ZsEzO6G9iT+PNw4Q7ltll1GfJHV4fKphuHWgKFzGHWi4alTlTnpk1SPPk41X+l2RB7rLfIhnB9Q==",
+            "version": "4.10.0",
+            "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.10.0.tgz",
+            "integrity": "sha512-7dezwAs+k6yXVFZ+MaL8VnE+APobiO3zvpp3rBHe/HmWQ+avwh0Q3d0xxacOiBybZZ3syTZw9HXzpa3YNbAZDQ==",
             "dev": true,
             "dependencies": {
                 "@types/bonjour": "^3.5.9",
@@ -13192,7 +13170,7 @@
                 "chokidar": "^3.5.3",
                 "colorette": "^2.0.10",
                 "compression": "^1.7.4",
-                "connect-history-api-fallback": "^1.6.0",
+                "connect-history-api-fallback": "^2.0.0",
                 "default-gateway": "^6.0.3",
                 "express": "^4.17.3",
                 "graceful-fs": "^4.2.6",
@@ -13215,6 +13193,10 @@
             },
             "engines": {
                 "node": ">= 12.13.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
             },
             "peerDependencies": {
                 "webpack": "^4.37.0 || ^5.0.0"
@@ -15441,6 +15423,24 @@
                 "@sinonjs/commons": "^1.7.0"
             }
         },
+        "@terraformer/arcgis": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/@terraformer/arcgis/-/arcgis-2.1.2.tgz",
+            "integrity": "sha512-IvdfqehcNAUtKU1OFMKwPT8EvdKlVFZ7q7ZKzkIF8XzYZIVsZLuXuOS1UBdRh5u/o+X5Gax7jiZhD8U/4TV+Jw==",
+            "requires": {
+                "@terraformer/common": "^2.1.2"
+            }
+        },
+        "@terraformer/common": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/@terraformer/common/-/common-2.1.2.tgz",
+            "integrity": "sha512-cwPdTFzIpekZhZRrgDEkqLKNPoqbyCBQHiemaovnGIeUx0Pl336MY/eCxzJ5zXkrQLVo9zPalq/vYW5HnyKevQ=="
+        },
+        "@terraformer/wkt": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/@terraformer/wkt/-/wkt-2.1.2.tgz",
+            "integrity": "sha512-2AyTBWqSfvGs4mTkuOMTdnL0Em6+awGyQd6f0nAMenoRLPWG05nWxxOHP8qKJVLmfZjkr0JfIWlakPgIyNgV7g=="
+        },
         "@ts-morph/common": {
             "version": "0.7.5",
             "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.7.5.tgz",
@@ -15596,11 +15596,6 @@
                 "@types/qs": "*",
                 "@types/range-parser": "*"
             }
-        },
-        "@types/geojson": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-1.0.6.tgz",
-            "integrity": "sha512-Xqg/lIZMrUd0VRmSRbCAewtwGZiAk3mEUDvV4op1tGl+LvyPcb/MIOSxTl9z+9+J+R4/vpjiCAT4xeKzH9ji1w=="
         },
         "@types/glob": {
             "version": "7.1.3",
@@ -16989,9 +16984,9 @@
             "dev": true
         },
         "connect-history-api-fallback": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz",
-            "integrity": "sha512-e54B99q/OUoH64zYYRf3HBP5z24G38h5D3qXu23JGRoigpX5Ss4r9ZnDk3g0Z8uQC2x2lPaJ+UlWBc1ZWBWdLg==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-2.0.0.tgz",
+            "integrity": "sha512-U73+6lQFmfiNPrYbXqr6kZ1i1wiRqXnp2nhMsINseWXO8lDau0LGEffJ8kQi4EjLZympVgRdvqjAgiZ1tgzDDA==",
             "dev": true
         },
         "content-disposition": {
@@ -22881,36 +22876,10 @@
                 "supports-hyperlinks": "^2.0.0"
             }
         },
-        "terraformer": {
-            "version": "1.0.12",
-            "resolved": "https://registry.npmjs.org/terraformer/-/terraformer-1.0.12.tgz",
-            "integrity": "sha512-MokUp0+MFal4CmJDVL6VAO1bKegeXcBM2RnPVfqcFIp2IIv8EbPAjG0j/vEy/vuKB8NVMMSF2vfpVS/QLe4DBg==",
-            "requires": {
-                "@types/geojson": "^7946.0.0 || ^1.0.0"
-            }
-        },
-        "terraformer-arcgis-parser": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/terraformer-arcgis-parser/-/terraformer-arcgis-parser-1.1.0.tgz",
-            "integrity": "sha512-bvxEtpiS22Lz1ciaXP/MMLTlJkrHWLBV/y7VBeTLHtZnz/Ngq4wF3RqrpjzP6ojJjxvcdDlvs+UFs3wicoT1Vg==",
-            "requires": {
-                "@types/geojson": "^1.0.0",
-                "terraformer": "~1.0.4"
-            }
-        },
-        "terraformer-wkt-parser": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/terraformer-wkt-parser/-/terraformer-wkt-parser-1.2.1.tgz",
-            "integrity": "sha512-+CJyNLWb3lJ9RsZMTM66BY0MT3yIo4l4l22Jd9CrZuwzk54fsu4Sc7zejuS9fCITTuTQy3p06d4MZMVI7v5wSg==",
-            "requires": {
-                "@types/geojson": "^1.0.0",
-                "terraformer": "~1.0.5"
-            }
-        },
         "terser": {
-            "version": "5.14.2",
-            "resolved": "https://registry.npmjs.org/terser/-/terser-5.14.2.tgz",
-            "integrity": "sha512-oL0rGeM/WFQCUd0y2QrWxYnq7tfSuKBiqTjRPWrRgB46WD/kiwHwF8T23z78H6Q6kGCuuHcPB+KULHRdxvVGQA==",
+            "version": "5.14.1",
+            "resolved": "https://registry.npmjs.org/terser/-/terser-5.14.1.tgz",
+            "integrity": "sha512-+ahUAE+iheqBTDxXhTisdA8hgvbEG1hHOQ9xmNjeUJSoi6DU/gMrKNcfZjHkyY6Alnuyc+ikYJaxxfHkT3+WuQ==",
             "dev": true,
             "requires": {
                 "@jridgewell/source-map": "^0.3.2",
@@ -23494,9 +23463,9 @@
             }
         },
         "webpack-dev-server": {
-            "version": "4.9.2",
-            "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.9.2.tgz",
-            "integrity": "sha512-H95Ns95dP24ZsEzO6G9iT+PNw4Q7ltll1GfJHV4fKphuHWgKFzGHWi4alTlTnpk1SPPk41X+l2RB7rLfIhnB9Q==",
+            "version": "4.10.0",
+            "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.10.0.tgz",
+            "integrity": "sha512-7dezwAs+k6yXVFZ+MaL8VnE+APobiO3zvpp3rBHe/HmWQ+avwh0Q3d0xxacOiBybZZ3syTZw9HXzpa3YNbAZDQ==",
             "dev": true,
             "requires": {
                 "@types/bonjour": "^3.5.9",
@@ -23511,7 +23480,7 @@
                 "chokidar": "^3.5.3",
                 "colorette": "^2.0.10",
                 "compression": "^1.7.4",
-                "connect-history-api-fallback": "^1.6.0",
+                "connect-history-api-fallback": "^2.0.0",
                 "default-gateway": "^6.0.3",
                 "express": "^4.17.3",
                 "graceful-fs": "^4.2.6",

--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
         "test": "jest"
     },
     "dependencies": {
-        "terraformer-arcgis-parser": "^1.1.0",
-        "terraformer-wkt-parser": "^1.2.1"
+        "@terraformer/arcgis": "^2.1.2",
+        "@terraformer/wkt": "^2.1.2"
     },
     "devDependencies": {
         "@babel/core": "^7.18.5",

--- a/src/activities/ConvertArcGisGeometryToGeoJson.ts
+++ b/src/activities/ConvertArcGisGeometryToGeoJson.ts
@@ -1,5 +1,5 @@
 import type { IActivityHandler } from "@geocortex/workflow/runtime/IActivityHandler";
-import { parse } from "terraformer-arcgis-parser";
+import { arcgisToGeoJSON } from "@terraformer/arcgis";
 
 /** An interface that defines the inputs of the activity. */
 export interface ConvertArcGisGeometryToGeoJsonInputs {
@@ -33,7 +33,7 @@ export class ConvertArcGisGeometryToGeoJson implements IActivityHandler {
             throw new Error("geometry is required");
         }
 
-        const agsGeometry = parse(inputs.geometry);
+        const agsGeometry = arcgisToGeoJSON(inputs.geometry);
 
         return {
             result: agsGeometry,

--- a/src/activities/ConvertArcGisGeometryToGeoJson.ts
+++ b/src/activities/ConvertArcGisGeometryToGeoJson.ts
@@ -33,10 +33,15 @@ export class ConvertArcGisGeometryToGeoJson implements IActivityHandler {
             throw new Error("geometry is required");
         }
 
-        const agsGeometry = arcgisToGeoJSON(inputs.geometry);
+        const geoJson = arcgisToGeoJSON(inputs.geometry);
+
+        // The conversion will just result in an empty object if the input isn't valid
+        if (Object.keys(geoJson).length === 0) {
+            throw new Error("geometry was not valid");
+        }
 
         return {
-            result: agsGeometry,
+            result: geoJson,
         };
     }
 }

--- a/src/activities/ConvertGeoJsonToArcGisGeometry.ts
+++ b/src/activities/ConvertGeoJsonToArcGisGeometry.ts
@@ -1,5 +1,5 @@
 import type { IActivityHandler } from "@geocortex/workflow/runtime/IActivityHandler";
-import { convert } from "terraformer-arcgis-parser";
+import { geojsonToArcGIS } from "@terraformer/arcgis";
 
 /** An interface that defines the inputs of the activity. */
 export interface ConvertGeoJsonToArcGisGeometryInputs {
@@ -34,7 +34,7 @@ export class ConvertGeoJsonToArcGisGeometry implements IActivityHandler {
             throw new Error("geoJSON is required");
         }
 
-        const agsGeometry = convert(inputs.geoJSON);
+        const agsGeometry = geojsonToArcGIS(inputs.geoJSON);
 
         // The convert will just result in an empty object if it isn't valid GeoJSON
         if (Object.keys(agsGeometry).length === 0) {

--- a/src/activities/ConvertGeoJsonToArcGisGeometry.ts
+++ b/src/activities/ConvertGeoJsonToArcGisGeometry.ts
@@ -36,7 +36,7 @@ export class ConvertGeoJsonToArcGisGeometry implements IActivityHandler {
 
         const agsGeometry = geojsonToArcGIS(inputs.geoJSON);
 
-        // The convert will just result in an empty object if it isn't valid GeoJSON
+        // The conversion will just result in an empty object if the input isn't valid
         if (Object.keys(agsGeometry).length === 0) {
             throw new Error("geoJSON was not valid");
         }

--- a/src/activities/ConvertGeoJsonToWkt.ts
+++ b/src/activities/ConvertGeoJsonToWkt.ts
@@ -1,5 +1,5 @@
 import type { IActivityHandler } from "@geocortex/workflow/runtime/IActivityHandler";
-import { convert } from "terraformer-wkt-parser";
+import { geojsonToWKT } from "@terraformer/wkt";
 
 /** An interface that defines the inputs of the activity. */
 export interface ConvertGeoJsonToWktInputs {
@@ -27,13 +27,12 @@ export interface ConvertGeoJsonToWktOutputs {
  * @unsupportedApps GMV
  */
 export class ConvertGeoJsonToWkt implements IActivityHandler {
-    /** Perform the execution logic of the activity. */
     execute(inputs: ConvertGeoJsonToWktInputs): ConvertGeoJsonToWktOutputs {
         if (!inputs.geoJSON) {
             throw new Error("geoJSON is required");
         }
 
-        const wkt = convert(inputs.geoJSON);
+        const wkt = geojsonToWKT(inputs.geoJSON);
         return {
             result: wkt,
         };

--- a/src/activities/ConvertWktToGeoJson.ts
+++ b/src/activities/ConvertWktToGeoJson.ts
@@ -1,5 +1,5 @@
 import type { IActivityHandler } from "@geocortex/workflow/runtime/IActivityHandler";
-import { parse } from "terraformer-wkt-parser";
+import { wktToGeoJSON } from "@terraformer/wkt";
 
 /** An interface that defines the inputs of the activity. */
 export interface ConvertWktToGeoJsonInputs {
@@ -32,7 +32,7 @@ export class ConvertWktToGeoJson implements IActivityHandler {
             throw new Error("wktGeometry is required");
         }
 
-        const geoJson = parse(inputs.wktGeometry);
+        const geoJson = wktToGeoJSON(inputs.wktGeometry);
         return {
             result: geoJson,
         };

--- a/src/activities/__tests__/ConvertArcGisGeometryToGeoJson.test.ts
+++ b/src/activities/__tests__/ConvertArcGisGeometryToGeoJson.test.ts
@@ -24,7 +24,7 @@ describe("ConvertArcGisGeometryToGeoJson", () => {
     it("throws if geometry input is not valid ArcGIS geometry", () => {
         const activity = new ConvertArcGisGeometryToGeoJson();
         expect(() => activity.execute({ geometry: { foo: "baz" } })).toThrow(
-            "Unknown type:"
+            "geometry was not valid"
         );
     });
 });


### PR DESCRIPTION
`terraformer-arcgis-parser` and `terraformer-wkt-parser` have been deprecated in favour of `@terraformer/arcgis` and `@terraformer/wkt`.

Even though the new packages _should_ be equivalent I am marking this as a breaking change.